### PR TITLE
Clearfix content area so footer doesn't overlap

### DIFF
--- a/app/assets/stylesheets/active_skin.css.sass
+++ b/app/assets/stylesheets/active_skin.css.sass
@@ -100,6 +100,7 @@ body.active_admin
       background: lighten( $skinActiveColor, 10% ) !important
 
 #active_admin_content
+  @include clearfix
   .table_tools
     height: 30px
   a.table_tools_button, .table_tools .dropdown_menu_button


### PR DESCRIPTION
Since many elements in #active_admin_content are floated, it doesn't have a height. That causes the fixed position footer to sometimes overlap content. This commit adds the clearfix mixin to #active_admin_content so that its height is properly set.
